### PR TITLE
Fixed path handling

### DIFF
--- a/tools/packages/bulk-test/src/findBulkTests.ts
+++ b/tools/packages/bulk-test/src/findBulkTests.ts
@@ -57,16 +57,12 @@ async function findGlobFiles(
   exclude: string[] | undefined,
 ): Promise<string[]> {
   const fullBaseDir = path.resolve(baseDir);
-  const cwd = process.cwd();
   const skip = exclude ?? [];
-  try {
-    process.chdir(fullBaseDir);
-    const futurePaths =
-      globs?.map(g => glob(g, { ignore: ["node_modules/**"] })) ?? [];
-    const pathSets = await Promise.all(futurePaths);
-    const filePaths = pathSets.flat();
-    return filePaths.filter(p => !skip.some(s => p.includes(s)));
-  } finally {
-    process.chdir(cwd);
-  }
+  const futurePaths =
+    globs?.map(g =>
+      glob(g, { ignore: ["node_modules/**"], cwd: fullBaseDir }),
+    ) ?? [];
+  const pathSets = await Promise.all(futurePaths);
+  const filePaths = pathSets.flat();
+  return filePaths.filter(p => !skip.some(s => p.includes(s)));
 }

--- a/tools/packages/wesl-link/src/cli.ts
+++ b/tools/packages/wesl-link/src/cli.ts
@@ -57,28 +57,26 @@ function parseArgs(args: string[]) {
 }
 
 async function linkNormally(paths: string[]): Promise<void> {
+  const weslRoot = getBaseDir();
   const pathAndTexts = paths.map(f => {
     const text = fs.readFileSync(f, { encoding: "utf8" });
-    const relativePath = path.relative(process.cwd(), f);
+    const relativePath = path.relative(weslRoot, f);
     const basedPath = "./" + normalize(relativePath);
     return [basedPath, text];
   });
-  const rootModuleRelative = path.relative(getBaseDir(), paths[0]);
-  const rootModuleName = noSuffix(rootModuleRelative);
+  const rootModuleName = noSuffix(path.relative(weslRoot, paths[0]));
   const weslSrc = Object.fromEntries(pathAndTexts);
-
-  const weslRoot = path.relative(process.cwd(), getBaseDir());
 
   // TODO conditions
   // TODO external defines
   if (argv.emit) {
-    const linked = await link({ weslSrc, rootModuleName, weslRoot });
+    const linked = await link({ weslSrc, rootModuleName });
     if (argv.emit) log(linked.dest);
   }
   if (argv.details) {
     const registry = parsedRegistry();
     try {
-      parseIntoRegistry(weslSrc, registry, "package", weslRoot);
+      parseIntoRegistry(weslSrc, registry, "package");
     } catch (e) {
       console.error(e);
     }

--- a/tools/packages/wesl-link/src/cli.ts
+++ b/tools/packages/wesl-link/src/cli.ts
@@ -2,7 +2,7 @@ import { createTwoFilesPatch } from "diff";
 import fs from "fs";
 import { enableTracing, log } from "mini-parse";
 import path from "path";
-import { astToString, link, normalize, noSuffix, scopeToString } from "wesl";
+import { astToString, link, noSuffix, scopeToString } from "wesl";
 import yargs from "yargs";
 import {
   parsedRegistry,
@@ -61,8 +61,7 @@ async function linkNormally(paths: string[]): Promise<void> {
   const pathAndTexts = paths.map(f => {
     const text = fs.readFileSync(f, { encoding: "utf8" });
     const relativePath = path.relative(weslRoot, f);
-    const basedPath = "./" + normalize(relativePath);
-    return [basedPath, text];
+    return [toUnixPath(relativePath), text];
   });
   const rootModuleName = noSuffix(path.relative(weslRoot, paths[0]));
   const weslSrc = Object.fromEntries(pathAndTexts);
@@ -92,6 +91,14 @@ async function linkNormally(paths: string[]): Promise<void> {
 
   // TODO diff
   // if (argv.diff) printDiff(srcPath, origWgsl, linked);
+}
+
+function toUnixPath(p: string): string {
+  if (path.sep !== "/") {
+    return p.replaceAll(path.sep, "/");
+  } else {
+    return p;
+  }
 }
 
 function externalDefines(): Record<string, string> {

--- a/tools/packages/wesl-plugin/src/LinkExtension.ts
+++ b/tools/packages/wesl-plugin/src/LinkExtension.ts
@@ -12,7 +12,6 @@ async function emitLinkJs(
   baseId: string,
   api: PluginExtensionApi,
 ): Promise<string> {
-  const { weslRoot } = await api.weslToml();
   const weslSrc = await api.weslSrc();
   const rootModule = await api.weslMain(baseId);
   const rootModuleName = noSuffix(rootModule);
@@ -25,15 +24,19 @@ async function emitLinkJs(
 
   const paramsName = `link${rootName}Config`;
 
+  const linkSettings = JSON.stringify(
+    {
+      rootModuleName,
+      weslSrc,
+      dependencies: packages,
+    },
+    null,
+    2,
+  );
+
   const src = `
     ${bundleImports}
-    export const ${paramsName} = {
-      rootModuleName: "${rootModuleName}",
-      weslRoot: "${weslRoot}",  
-      weslSrc: ${JSON.stringify(weslSrc, null, 2)},
-      dependencies: [${packages.join(", ")}],
-    };
-
+    export const ${paramsName} = ${linkSettings};
     export default ${paramsName};
     `;
 

--- a/tools/packages/wesl-plugin/src/PluginExtension.ts
+++ b/tools/packages/wesl-plugin/src/PluginExtension.ts
@@ -1,5 +1,5 @@
 import { ParsedRegistry, WeslJsPlugin } from "wesl";
-import { WeslToml } from "./weslPlugin.ts";
+import { WeslTomlInfo } from "./weslPlugin.ts";
 
 /** function type required for for emit extensions */
 export type ExtensionEmitFn = (
@@ -19,7 +19,7 @@ export interface PluginExtension extends WeslJsPlugin {
 
 /** api supplied to plugin extensions */
 export interface PluginExtensionApi {
-  weslToml: () => Promise<WeslToml>;
+  weslToml: () => Promise<WeslTomlInfo>;
   weslSrc: () => Promise<Record<string, string>>;
   weslRegistry: () => Promise<ParsedRegistry>;
   weslMain: (baseId: string) => Promise<string>;

--- a/tools/packages/wesl-plugin/test/linkExtension/LinkExtension.test.ts
+++ b/tools/packages/wesl-plugin/test/linkExtension/LinkExtension.test.ts
@@ -8,10 +8,9 @@ test("verify ?link", async () => {
 
   const { rootModuleName, weslRoot, weslSrc, dependencies } = linkParams;
   expect(rootModuleName).toMatchInlineSnapshot(`"./app"`);
-  expect(weslRoot).toMatchInlineSnapshot(`"shaders"`);
   expect(weslSrc).toMatchInlineSnapshot(`
     {
-      "./shaders/app.wesl": "import random_wgsl::pcg_2u_3f;
+      "./app.wesl": "import random_wgsl::pcg_2u_3f;
 
     main() {
        let a = pcg_2u3f(vec2u(1, 2)); 

--- a/tools/packages/wesl/src/Linker.ts
+++ b/tools/packages/wesl/src/Linker.ts
@@ -38,9 +38,6 @@ export interface LinkParams {
    */
   weslSrc: Record<string, string>;
 
-  /** root directory prefix for sources, e.g. /shaders */
-  weslRoot?: string;
-
   /** name of root wesl module
    *    for an app, the root module normally contains the '@compute', '@vertex' or '@fragment' entry points
    *    for a library, the root module defines the public api fo the library
@@ -78,9 +75,9 @@ export type VirtualLibraryFn = (conditions: Conditions) => string;
  * Only code that is valid with the current conditions is included in the output.
  */
 export async function link(params: LinkParams): Promise<SrcMap> {
-  const { weslSrc, weslRoot = "", libs = [] } = params;
+  const { weslSrc, libs = [] } = params;
   const registry = parsedRegistry();
-  parseIntoRegistry(weslSrc, registry, "package", weslRoot);
+  parseIntoRegistry(weslSrc, registry, "package");
   parseLibsIntoRegistry(libs, registry);
   return linkRegistry({ registry, ...params });
 }

--- a/tools/packages/wesl/src/ParsedRegistry.ts
+++ b/tools/packages/wesl/src/ParsedRegistry.ts
@@ -38,7 +38,11 @@ export function selectModule(
   let modulePath: string;
   if (selectPath.includes("::")) {
     modulePath = selectPath;
-  } else if (selectPath.includes("/")) {
+  } else if (
+    selectPath.includes("/") ||
+    selectPath.endsWith(".wesl") ||
+    selectPath.endsWith(".wgsl")
+  ) {
     modulePath = fileToModulePath(selectPath, packageName);
   } else {
     modulePath = packageName + "::" + selectPath;
@@ -85,7 +89,7 @@ export function parseLibsIntoRegistry(
 
 const libRegex = /^lib\.w[eg]sl$/i;
 
-/** convert a file path (./shaders/foo/bar.wesl) and a wesl root (./shaders)
+/** convert a file path (./foo/bar.wesl)
  *  to a module path (package::foo::bar) */
 function fileToModulePath(filePath: string, packageName: string): string {
   if (filePath.includes("::")) {

--- a/tools/packages/wesl/src/ParsedRegistry.ts
+++ b/tools/packages/wesl/src/ParsedRegistry.ts
@@ -39,7 +39,7 @@ export function selectModule(
   if (selectPath.includes("::")) {
     modulePath = selectPath;
   } else if (selectPath.includes("/")) {
-    modulePath = fileToModulePath(selectPath, packageName, "");
+    modulePath = fileToModulePath(selectPath, packageName);
   } else {
     modulePath = packageName + "::" + selectPath;
   }
@@ -58,11 +58,10 @@ export function parseIntoRegistry(
   srcFiles: Record<string, string>,
   registry: ParsedRegistry,
   packageName: string = "package",
-  weslRoot: string = "",
 ): void {
   const srcModules: SrcModule[] = Object.entries(srcFiles).map(
     ([filePath, src]) => {
-      const modulePath = fileToModulePath(filePath, packageName, weslRoot);
+      const modulePath = fileToModulePath(filePath, packageName);
       return { modulePath, filePath, src };
     },
   );
@@ -88,11 +87,7 @@ const libRegex = /^lib\.w[eg]sl$/i;
 
 /** convert a file path (./shaders/foo/bar.wesl) and a wesl root (./shaders)
  *  to a module path (package::foo::bar) */
-function fileToModulePath(
-  filePath: string,
-  packageName: string,
-  weslRoot: string,
-): string {
+function fileToModulePath(filePath: string, packageName: string): string {
   if (filePath.includes("::")) {
     // already a module path
     return filePath;
@@ -102,12 +97,7 @@ function fileToModulePath(
     return packageName;
   }
 
-  const rootStart = filePath.indexOf(weslRoot);
-  if (rootStart === -1) {
-    throw new Error(`file ${filePath} not in root ${weslRoot}`);
-  }
-  const postRoot = filePath.slice(rootStart + weslRoot.length);
-  const strippedPath = noSuffix(normalize(postRoot));
+  const strippedPath = noSuffix(normalize(filePath));
   const moduleSuffix = strippedPath.replaceAll("/", "::");
   const modulePath = packageName + "::" + moduleSuffix;
   return modulePath;

--- a/tools/packages/wesl/src/PathUtil.ts
+++ b/tools/packages/wesl/src/PathUtil.ts
@@ -1,26 +1,5 @@
 /** simplistic path manipulation utilities */
 
-export function relativePath(
-  srcPath: string | undefined,
-  reqPath: string,
-): string {
-  if (!srcPath) return reqPath;
-  const srcDir = dirname(srcPath);
-  const relative = join(srcDir, reqPath);
-  return relative;
-}
-
-export function dirname(path: string): string {
-  const lastSlash = path.lastIndexOf("/");
-  if (lastSlash === -1) return ".";
-  return path.slice(0, lastSlash);
-}
-
-export function join(a: string, b: string): string {
-  const joined = b.startsWith("/") ? a + b : a + "/" + b;
-  return normalize(joined);
-}
-
 /** return path with ./ and foo/.. elements removed */
 export function normalize(path: string): string {
   const segments = path.split("/");

--- a/tools/packages/wesl/src/VirtualFilesystem.ts
+++ b/tools/packages/wesl/src/VirtualFilesystem.ts
@@ -1,0 +1,89 @@
+import { assertThat } from "./Assertions";
+import { isIdent } from "./parse/WeslStream";
+
+/**
+ * A relative, normalized, Linux-style path ending with a file.
+ * All file and folder names must be valid WGSL identifiers.
+ * `.wgsl` and `.wesl` are the supported file extensions.
+ */
+export type WeslPath = string & { __weslPath: never };
+
+/** A async virtual filesystem, can be backed by an in-memory map, or by a real filesystem, or by HTTP requests */
+export interface VirtualFilesystem {
+  /**
+   * The WESL module loading uses this to load files.
+   */
+  readFile(path: WeslPath): Promise<string | null>;
+}
+
+/** Creates a static filesystem from relative, normalized, Linux-style paths.
+ * All file and folder names must be valid WGSL identifiers.
+ * `.wgsl` and `.wesl` are the supported file extensions.
+ */
+export function staticFilesystem(
+  files: Record<string, string>,
+): VirtualFilesystem {
+  // Avoid accidentally having a file called `toString`
+  const filesystemMap = new Map(
+    Object.entries(files).map(([path, contents]) => [
+      makeWeslPath(path),
+      contents,
+    ]),
+  );
+  function readFile(path: WeslPath): Promise<string | null> {
+    const file = filesystemMap.get(path) ?? null;
+    return Promise.resolve(file);
+  }
+  return {
+    readFile,
+  };
+}
+
+const fileNameRegex = /^(?<name>[^.]+)\.(?<extension>wgsl|wesl)$/;
+
+export function makeWeslPath(path: string): WeslPath {
+  if (path.startsWith("/")) {
+    throw new Error(
+      `Paths must be relative, but absolute path was found ${path}`,
+    );
+  }
+  if (path.includes("\\")) {
+    throw new Error(`Paths must be Linux-style, but \\ was found ${path}`);
+  }
+  if (path.includes("..")) {
+    throw new Error(`Paths must be normalized, but .. was found ${path}`);
+  }
+
+  const segments = path.split("/");
+  if (segments[0] === ".") {
+    segments.shift();
+  }
+  const lastSegment = segments.pop();
+  if (lastSegment === undefined) {
+    throw new Error(`Path is missing a file name ${path}`);
+  } else {
+    const matches = lastSegment.match(fileNameRegex);
+    if (matches === null) {
+      throw new Error(
+        `Expected a valid file name, but ${lastSegment} is not one ${path}`,
+      );
+    }
+    assertThat(matches.groups !== undefined);
+    const { name } = matches.groups;
+    if (!isIdent(name)) {
+      throw new Error(
+        `Path must only contain valid WGSL idents, but ${name} is not one ${path}`,
+      );
+    }
+  }
+
+  for (const segment of segments) {
+    if (!isIdent(segment)) {
+      throw new Error(
+        `Path must only contain valid WGSL idents, but ${segment} is not one ${path}`,
+      );
+    }
+  }
+
+  return path as WeslPath;
+}

--- a/tools/packages/wesl/src/parse/WeslStream.ts
+++ b/tools/packages/wesl/src/parse/WeslStream.ts
@@ -24,6 +24,17 @@ const symbolSet =
 const ident =
   /(?:(?:[_\p{XID_Start}][\p{XID_Continue}]+)|(?:[\p{XID_Start}]))/u;
 
+/** Checks if a word is a valid WGSL ident, and not a keyword */
+export function isIdent(text: string): boolean {
+  if (text.match(ident)?.[0] !== text) {
+    return false;
+  }
+  if (keywordOrReserved.has(text)) {
+    return false;
+  }
+  return true;
+}
+
 const keywordOrReserved = new Set(keywords.concat(reservedWords));
 
 const digits = new RegExp(

--- a/tools/packages/wesl/src/test/PrettyGrammar.test.ts
+++ b/tools/packages/wesl/src/test/PrettyGrammar.test.ts
@@ -1,6 +1,5 @@
 import { or, parserToString, seq } from "mini-parse";
 import { expect, test } from "vitest";
-// import { weslRoot } from "../WESLGrammar.ts";
 
 test("print grammar", () => {
   const p: any = or("a", "b", () => p);

--- a/tools/packages/wesl/src/test/VirtualFilesystem.test.ts
+++ b/tools/packages/wesl/src/test/VirtualFilesystem.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import { makeWeslPath } from "../VirtualFilesystem";
+
+test("accept valid paths", () => {
+  const paths = ["./foo.wesl", "foo.wesl", "bar.wgsl", "./foo/bar/baz.wgsl"];
+  for (const p of paths) {
+    expect(makeWeslPath(p)).toBe(p);
+  }
+});
+
+test("reject invalid paths", () => {
+  const paths = [
+    ".foo.wesl",
+    "foo.js",
+    "../bar.wgsl",
+    "./foo/./bar/baz.wgsl",
+    "./foo//bar.wgsl",
+    ".\\foo.wgsl",
+  ];
+  for (const p of paths) {
+    expect(() => makeWeslPath(p)).toThrow();
+  }
+});


### PR DESCRIPTION
After another round of refactoring that I struggled with, since I couldn't tell if I was breaking the linker plugin, I finally decided to look at the path handling. I left a lot of comments as a GitHub review, to explain the rationale behind some of the changes.

Fundamentally what we want is
- Linker-Plugin, CLI, Bulk Test: They use filesystem paths, in their disgusting rawness
- WESL: Only gets unix-style, relative filesystem paths that are valid WGSL identifiers
  - Unix-style: Slashes as separators. 
  - Valid WGSL identifiers: This lets us detect when a path has a `\`. It would still be a valid Unix path, but it'd clearly be wrong in the context of the linker
  - Relative paths: They have to be relative to the wesl root. This lets us avoid doing the tricky `path.relative()` inside the cross-platform linker code. For logging, we'll eventually want to pass along absolute filesystem paths or similar. Ones that will never get used for anything other than logging.
