### PR TITLE
Feat/underscore mangler

### DIFF
--- a/tools/packages/wesl/src/Linker.ts
+++ b/tools/packages/wesl/src/Linker.ts
@@ -2,6 +2,7 @@ import { SrcMap, SrcMapBuilder, tracing } from "mini-parse";
 import { AbstractElem, ModuleElem } from "./AbstractElems.ts";
 import { bindIdents } from "./BindIdents.ts";
 import { lowerAndEmit } from "./LowerAndEmit.ts";
+import { ManglerFn } from "./Mangler.ts";
 import {
   parsedRegistry,
   ParsedRegistry,
@@ -64,6 +65,9 @@ export interface LinkParams {
    * Users can import the values from wesl code via the `constants' virtual library:
    *  `import constants::num_lights;` */
   constants?: Record<string, string | number>;
+
+  /** function to construct globally unique wgsl identifiers */
+  mangler?: ManglerFn;
 }
 
 export type VirtualLibraryFn = (conditions: Conditions) => string;
@@ -88,7 +92,12 @@ export async function link(params: LinkParams): Promise<SrcMap> {
 export interface LinkRegistryParams
   extends Pick<
     LinkParams,
-    "rootModuleName" | "conditions" | "virtualLibs" | "config" | "constants"
+    | "rootModuleName"
+    | "conditions"
+    | "virtualLibs"
+    | "config"
+    | "constants"
+    | "mangler"
   > {
   registry: ParsedRegistry;
 }
@@ -116,8 +125,9 @@ interface BoundAndTransformed {
 export function bindAndTransform(
   params: LinkRegistryParams,
 ): BoundAndTransformed {
-  const { registry, rootModuleName = "main", conditions = {} } = params;
-  const rootModule = getRootModule(registry, rootModuleName);
+  const { registry, mangler } = params;
+  const { rootModuleName = "main", conditions = {} } = params;
+  const rootAst = getRootModule(registry, rootModuleName);
 
   // setup virtual modules from code generation or host constants provided by the user
   const { constants, config } = params;
@@ -129,10 +139,11 @@ export function bindAndTransform(
 
   /* --- Step #2   Binding Idents --- */
   // link active Ident references to declarations, and uniquify global declarations
-  const bindResults = bindIdents(rootModule, registry, conditions, virtuals);
+  const bindParams = { rootAst, registry, conditions, virtuals, mangler };
+  const bindResults = bindIdents(bindParams);
   const { globalNames, decls: newDecls } = bindResults;
 
-  const transformedAst = applyTransformPlugins(rootModule, globalNames, config);
+  const transformedAst = applyTransformPlugins(rootAst, globalNames, config);
   return { transformedAst, newDecls };
 }
 

--- a/tools/packages/wesl/src/Mangler.ts
+++ b/tools/packages/wesl/src/Mangler.ts
@@ -1,0 +1,70 @@
+import { DeclIdent, SrcModule } from "./Scope.ts";
+/**
+ * A function for constructing a unique identifier name for a global declaration.
+ * Global names must be unique in the linked wgsl.
+ *
+ * Two manglers are currently available:
+ * . minimalMangle preserves original source names where possible
+ * . underscoreMangle constructs long but predictable names for every declaration
+ */
+export type ManglerFn = (
+  /** global declaration that needs a name */
+  decl: DeclIdent,
+
+  /** module that contains the declaration */
+  srcModule: SrcModule,
+
+  /** name at use site (possibly import as renamed from declaration) */
+  proposedName: string,
+
+  /** current set of mangled root level names for the linked result (read only) */
+  globalNames: Set<string>,
+) => string;
+
+/**
+ * Construct a globally unique name based on the declaration
+ * module path separated by underscores.
+ */
+export function underscoreMangle(
+  decl: DeclIdent,
+  srcModule: SrcModule,
+): string {
+  const { modulePath } = srcModule;
+  const unpackaged = modulePath.replace(/^package::/, "_");
+  const escaped = unpackaged.replace("_", "__");
+  const separated = escaped.replace("::", "_");
+  const mangled = separated + "_" + decl.originalName;
+  return mangled;
+}
+
+/**
+ * ManglerFn to construct a globally unique name
+ * using the requested name plus a uniquing number suffix if necessary
+ */
+export function minimalMangle(
+  _d: DeclIdent,
+  _s: SrcModule,
+  proposedName: string,
+  globalNames: Set<string>,
+): string {
+  return minimallyMangledName(proposedName, globalNames);
+}
+
+/**
+ * Construct a globally unique name by using the requested name if possible
+ * and appending a number suffix necessary
+ */
+export function minimallyMangledName(
+  proposedName: string,
+  globalNames: Set<string>,
+): string {
+  let renamed = proposedName;
+  let conflicts = 0;
+
+  // create a unique name
+  while (globalNames.has(renamed)) {
+    renamed = proposedName + conflicts++;
+  }
+
+  return renamed;
+}

--- a/tools/packages/wesl/src/Scope.ts
+++ b/tools/packages/wesl/src/Scope.ts
@@ -29,7 +29,7 @@ export interface RefIdent extends IdentBase {
   std?: true; // true if this is a standard wgsl identifier (like sin, or u32)
   ast: WeslAST; // AST from module that contains this ident (to find imports during decl binding)
   scope: Scope; // scope containing this reference (bind to decls starting from this scope)
-  refIdentElem?: RefIdentElem; // for error reporting
+  refIdentElem: RefIdentElem; // for error reporting and mangling
 }
 
 export interface DeclIdent extends IdentBase {

--- a/tools/packages/wesl/src/Scope.ts
+++ b/tools/packages/wesl/src/Scope.ts
@@ -3,7 +3,7 @@ import { WeslAST } from "./ParseWESL.ts";
 
 export interface SrcModule {
   /** module path "rand_pkg::sub::foo", or "package::main" */
-  modulePath: string; // TODO drop this?
+  modulePath: string;
 
   /** file path to the module for user error reporting e.g "rand_pkg:sub/foo.wesl", or "./sub/foo.wesl" */
   filePath: string;

--- a/tools/packages/wesl/src/TransformBindingStructs.ts
+++ b/tools/packages/wesl/src/TransformBindingStructs.ts
@@ -12,10 +12,10 @@ import {
   SyntheticElem,
   TypeTemplateParameter,
 } from "./AbstractElems.ts";
-import { declUniqueName } from "./BindIdents.ts";
 import { TransformedAST, WeslJsPlugin } from "./Linker.ts";
 import { visitAst } from "./LinkerUtil.ts";
 import { findDecl } from "./LowerAndEmit.ts";
+import { minimallyMangledName } from "./Mangler.ts";
 import {
   attributeToString,
   contentsToString,
@@ -153,7 +153,7 @@ export function transformBindingStruct(
     const { name: typeName } = typeRef!; // members should always have a typeRef.. TODO fix typing to show this
     const typeParameters = typeRef?.templateParams;
 
-    const varName = declUniqueName(memberName.name, globalNames);
+    const varName = minimallyMangledName(memberName.name, globalNames);
     member.mangledVarName = varName; // save new name so we can rewrite references to this member later
     globalNames.add(varName);
 

--- a/tools/packages/wesl/src/WESLCollect.ts
+++ b/tools/packages/wesl/src/WESLCollect.ts
@@ -70,6 +70,7 @@ export function refIdent(cc: CollectContext): RefIdentElem {
     ast: cc.app.stable,
     scope,
     id: identId++,
+    refIdentElem: null as any, // set below
   };
   const identElem: RefIdentElem = { kind, start, end, srcModule, ident };
   ident.refIdentElem = identElem;

--- a/tools/packages/wesl/src/test/Mangling.test.ts
+++ b/tools/packages/wesl/src/test/Mangling.test.ts
@@ -1,0 +1,21 @@
+import { test } from "vitest";
+import { underscoreMangle } from "../Mangler.ts";
+import { expectTrimmedMatch } from "./shared/StringUtil.ts";
+import { linkTestOpts } from "./TestUtil.ts";
+
+test("underscoreMangle", async () => {
+  const main = `
+    import package::file1::bar;
+fn main() { bar(); }
+  `;
+  const file1 = `
+    fn bar() {};
+  `;
+
+  const linked = await linkTestOpts({ mangler: underscoreMangle }, main, file1);
+  const expected = `
+    fn main() { __file1_bar(); }
+    fn __file1_bar() {}
+  `;
+  expectTrimmedMatch(linked, expected);
+});

--- a/tools/packages/wesl/src/test/TestUtil.ts
+++ b/tools/packages/wesl/src/test/TestUtil.ts
@@ -28,7 +28,7 @@ export async function linkTest(...rawWgsl: string[]): Promise<string> {
 
 export type LinkTestOpts = Pick<
   LinkParams,
-  "conditions" | "libs" | "config" | "virtualLibs" | "constants"
+  "conditions" | "libs" | "config" | "virtualLibs" | "constants" | "mangler"
 >;
 
 export async function linkTestOpts(

--- a/tools/packages/wesl/src/test/TransformBindingStructs.test.ts
+++ b/tools/packages/wesl/src/test/TransformBindingStructs.test.ts
@@ -47,9 +47,9 @@ test("transformBindingStruct", () => {
     }
   `;
 
-  const ast = parseTest(src);
-  bindIdents(ast, parsedRegistry(), {});
-  const bindingStruct = markBindingStructs(ast.moduleElem)[0];
+  const rootAst = parseTest(src);
+  bindIdents({ rootAst, registry: parsedRegistry() });
+  const bindingStruct = markBindingStructs(rootAst.moduleElem)[0];
   const newVars = transformBindingStruct(bindingStruct, new Set());
 
   const srcBuilder = new SrcMapBuilder();
@@ -77,10 +77,10 @@ test("findRefsToBindingStructs", () => {
     }
   `;
 
-  const ast = parseTest(src);
-  bindIdents(ast, parsedRegistry(), {});
-  markBindingStructs(ast.moduleElem)[0];
-  const found = findRefsToBindingStructs(ast.moduleElem);
+  const rootAst = parseTest(src);
+  bindIdents({ rootAst, registry: parsedRegistry() });
+  markBindingStructs(rootAst.moduleElem)[0];
+  const found = findRefsToBindingStructs(rootAst.moduleElem);
   expect(found.length).toBe(1);
   const foundAst = astToString(found[0].memberRef);
   expect(foundAst).toMatchInlineSnapshot(`
@@ -101,11 +101,11 @@ test("transformBindingReference", () => {
     }
   `;
 
-  const ast = parseTest(src);
-  bindIdents(ast, parsedRegistry(), {});
-  const bindingStruct = markBindingStructs(ast.moduleElem)[0];
+  const rootAst = parseTest(src);
+  bindIdents({ rootAst, registry: parsedRegistry() });
+  const bindingStruct = markBindingStructs(rootAst.moduleElem)[0];
   transformBindingStruct(bindingStruct, new Set());
-  const found = findRefsToBindingStructs(ast.moduleElem);
+  const found = findRefsToBindingStructs(rootAst.moduleElem);
   expect(found.length).toBe(1);
   const { memberRef, struct } = found[0];
   const synthElem = transformBindingReference(memberRef, struct);
@@ -130,9 +130,9 @@ test("lower binding structs", () => {
       let x = particles;
     }
   `;
-  const weslAst = parseTest(src);
-  const { globalNames } = bindIdents(weslAst, parsedRegistry(), {});
-  const tAst = { ...weslAst, globalNames, notableElems: {} };
+  const rootAst = parseTest(src);
+  const { globalNames } = bindIdents({ rootAst, registry: parsedRegistry() });
+  const tAst = { ...rootAst, globalNames, notableElems: {} };
   const lowered = lowerBindingStructs(tAst);
 
   const loweredAst = astToString(lowered.moduleElem);


### PR DESCRIPTION
Fix for #79. 

- Adds an optional mangler that follows the underscore style in [#87](https://github.com/wgsl-tooling-wg/wesl-spec/pull/87) plus two extensions noted in [#89](https://github.com/wgsl-tooling-wg/wesl-spec/issues/89).
- The juicy bit is `underscoreMangle` in `Mangler.ts`, along with `ManglerFn` type for plugging in alternative manglers.
- Most of the rest of [0b28262](https://github.com/wgsl-tooling-wg/wesl-js/commit/0b283627c359ce79dfd51d3f8c3e30564b25b324) is just plumbing a custom mangler through the linker. 
- A few other related small changes are in separate commits.
- The corresponding changes to the ImportCases tests are in [#6](https://github.com/wgsl-tooling-wg/wesl-testsuite/pull/6)