### PR TITLE
Implement new source map builder API

### DIFF
--- a/tools/packages/mini-parse/src/SrcMapBuilder.ts
+++ b/tools/packages/mini-parse/src/SrcMapBuilder.ts
@@ -1,79 +1,113 @@
+import { assertThat } from "./Assertions.js";
+import { Span } from "./Span.js";
 import { SrcMap, SrcMapEntry } from "./SrcMap.js";
 
 // TODO untested
 
-/**
- * Incrementally append to a string, tracking source references
- *
- * TODO: Offer a tree-like API, where I can pass in a large span, and then a bunch of child spans.
- * Like a large span that covers a whole attribute, and then smaller spans that only cover the attribute parameters.
- */
-export class SrcMapBuilder {
-  #fragments: string[] = [];
-  #destLength = 0;
-  #entries: SrcMapEntry[] = [];
-
-  constructor(public source: string) {}
-
-  /** append a string fragment to the destination string */
-  // TODO allow for src file name not just string (e.g. SrcModule)
-  add(fragment: string, srcStart: number, srcEnd: number): void {
-    // dlog({fragment})
-    const destStart = this.#destLength;
-    this.#destLength += fragment.length;
-    const destEnd = this.#destLength;
-
-    this.#fragments.push(fragment);
-    this.#entries.push({
-      src: this.source,
-      srcStart,
-      srcEnd,
-      destStart,
-      destEnd,
-    });
-  }
-
-  addSynthetic(
-    fragment: string,
-    syntheticSource: string,
-    srcStart: number,
-    srcEnd: number,
-  ): void {
-    // dlog({fragment})
-    const destStart = this.#destLength;
-    this.#destLength += fragment.length;
-    const destEnd = this.#destLength;
-
-    this.#fragments.push(fragment);
-    this.#entries.push({
-      src: syntheticSource,
-      srcStart,
-      srcEnd,
-      destStart,
-      destEnd,
-    });
-  }
-
-  /** append a synthetic newline, mapped to previous source location */
-  addNl(): void {
-    const lastEntry = this.#entries.at(-1) ?? { srcStart: 0, srcEnd: 0 };
-    const { srcStart, srcEnd } = lastEntry;
-    this.add("\n", srcStart, srcEnd);
-  }
-
-  /** copy a string fragment from the src to the destination string */
-  addCopy(srcStart: number, srcEnd: number): void {
-    const fragment = this.source.slice(srcStart, srcEnd);
-    this.add(fragment, srcStart, srcEnd);
-  }
-
-  /** return a SrcMap */
-  static build(builders: SrcMapBuilder[]): SrcMap {
-    const map = new SrcMap(
-      builders.map(b => b.#fragments.join("")).join(""),
-      builders.flatMap(b => b.#entries),
+export class SpannedText {
+  constructor(
+    /** Span of the text in the real source */
+    public readonly srcSpan: Span,
+    /** Text (and nested elements) at that location */
+    public readonly children: (string | SpannedText | SyntheticText)[],
+  ) {
+    let current = srcSpan[0];
+    for (const child of children) {
+      if (child instanceof SpannedText) {
+        assertThat(
+          current <= child.srcSpan[0],
+          "Children must be inserted in order",
+        );
+        current = child.srcSpan[1];
+      }
+    }
+    assertThat(
+      current <= srcSpan[1],
+      "Child spans must be contained within the parent span",
     );
-    map.compact();
-    return map;
   }
+
+  build(source: string): SrcMap {
+    let dest = "";
+    let entries: SrcMapEntry[] = [];
+
+    // SpannedText: We know the exact span
+    // string: We map them to the remaining span. Multiple strings in a row are merged.
+    // SyntheticText: Explicitly does not have a source span. (Span of zero)
+
+    function buildInner(spannedText: SpannedText) {
+      if (spannedText.children.length === 0) return;
+
+      let textStartSrc = spannedText.srcSpan[0];
+      for (let i = 0; i < spannedText.children.length; i++) {
+        const child = spannedText.children[i];
+        let destStart = dest.length;
+        if (child instanceof SpannedText) {
+          buildInner(child);
+          textStartSrc = child.srcSpan[1];
+        } else if (child instanceof SyntheticText) {
+          dest += child.value;
+          entries.push({
+            src: child.value,
+            srcStart: 0,
+            srcEnd: child.value.length,
+            destStart,
+            destEnd: dest.length,
+          });
+        } else {
+          // Text range goes until the next actual source span
+          dest += child;
+          // Merge next children if they're also text
+          while (
+            i + 1 < spannedText.children.length &&
+            typeof spannedText.children[i + 1] === "string"
+          ) {
+            dest += spannedText.children[i + 1];
+            i += 1;
+          }
+          // Now i points at the last string
+          // Skip over the synthetic texts, and find the end of the text
+          let srcEnd =
+            spannedText.children
+              .slice(i + 1)
+              .find(v => v instanceof SpannedText)?.srcSpan?.[0] ??
+            spannedText.srcSpan[1];
+          textStartSrc = srcEnd;
+          entries.push({
+            src: source,
+            srcStart: textStartSrc,
+            srcEnd,
+            destStart,
+            destEnd: dest.length,
+          });
+        }
+      }
+    }
+    buildInner(this);
+
+    return new SrcMap(dest, entries);
+  }
+}
+
+export function spannedText(
+  span: Span,
+  ...children: (string | SpannedText | SyntheticText)[]
+): SpannedText {
+  return new SpannedText(span, children);
+}
+
+export class SyntheticText {
+  constructor(public readonly value: string) {}
+}
+
+export function syntheticText(text: string): SyntheticText {
+  return new SyntheticText(text);
+}
+
+export function joinSrcMaps(srcMaps: SrcMap[]) {
+  let dest = srcMaps.map(v => v.dest).join("");
+  let entries = srcMaps.flatMap(v => v.entries);
+  const map = new SrcMap(dest, entries);
+  map.compact();
+  return map;
 }

--- a/tools/packages/wesl/src/WESLCollect.ts
+++ b/tools/packages/wesl/src/WESLCollect.ts
@@ -373,6 +373,8 @@ export const collectModule = collectElem(
   (cc: CollectContext, openElem: PartElem<ModuleElem>) => {
     const ccComplete = { ...cc, start: 0, end: cc.src.length }; // force module to cover entire source despite ws skipping
     const moduleElem: ModuleElem = withTextCover(openElem, ccComplete);
+    moduleElem.start = 0;
+    moduleElem.end = cc.src.length;
     const weslState: StableState = cc.app.stable;
     weslState.moduleElem = moduleElem;
     return moduleElem;


### PR DESCRIPTION
This implements a source map builder API that naturally deals with nesting. We often have syntax nodes along the lines of

```ts
// I made up an example!

interface ParenthesizedExpression {
  kind: "parenthesized-expression";
  expression: Expression; // expression inside the brackets

  // span of everything, including the brackets
  start: number;
  end: number; 
}
```
and the inner expression also has a `start` and `end`.

And for source maps, one wants to know what span the opening bracket, the inner expression, and the closing bracket have.

But that information is only implicitly there. The opening bracket is whatever is between the `start` and the `expression.start`. Then comes the `expression`'s text. And after `expression.end` comes the closing bracket.


This models that, and then flattens that info into our usual SrcMap :)
