### PR TITLE
Fix types path in wesl package.json

### DIFF
--- a/tools/packages/wesl/package.json
+++ b/tools/packages/wesl/package.json
@@ -25,11 +25,11 @@
   "repository": "github:wgsl-tooling-wg/wesl-js",
   "exports": {
     ".": {
-      "types": "./dist/tools/packages/wesl/src/index.d.ts"",
+      "types": "./dist/tools/packages/wesl/src/index.d.ts",
       "import": "./dist/index.js"
     },
     "./minified": {
-      "types": "./dist/tools/packages/wesl/src/index.d.ts"",
+      "types": "./dist/tools/packages/wesl/src/index.d.ts",
       "import": "./dist/minified.js"
     }
   },

--- a/tools/packages/wesl/package.json
+++ b/tools/packages/wesl/package.json
@@ -25,11 +25,11 @@
   "repository": "github:wgsl-tooling-wg/wesl-js",
   "exports": {
     ".": {
-      "types": "./dist/linker/src/index.d.ts",
+      "types": "./dist/tools/packages/wesl/src/index.d.ts"",
       "import": "./dist/index.js"
     },
     "./minified": {
-      "types": "./dist/linker/src/index.d.ts",
+      "types": "./dist/tools/packages/wesl/src/index.d.ts"",
       "import": "./dist/minified.js"
     }
   },


### PR DESCRIPTION
The new path matches the dist when downloading from npm