### PR TITLE
Add attribute parsing

### DIFF
--- a/tools/packages/wesl/src/AbstractElems.ts
+++ b/tools/packages/wesl/src/AbstractElems.ts
@@ -33,7 +33,9 @@ export type ContainerElem =
   | StructMemberElem
   | StuffElem
   | TypeRefElem
-  | VarElem;
+  | VarElem
+  | AnyStatement
+  | SwitchClause;
 
 /** Inspired by https://github.com/wgsl-tooling-wg/wesl-rs/blob/3b2434eac1b2ebda9eb8bfb25f43d8600d819872/crates/wgsl-parse/src/syntax.rs#L364 */
 export type ExpressionElem =
@@ -225,12 +227,14 @@ export interface IfAttribute {
 /** a const_assert statement */
 export interface ConstAssertElem extends ElemWithContentsBase {
   kind: "assert";
+  attributes: AttributeElem[];
 }
 
 /** a const declaration */
 export interface ConstElem extends ElemWithContentsBase {
   kind: "const";
   name: TypedDeclElem;
+  attributes: AttributeElem[];
 }
 
 export interface UnknownExpressionElem extends ElemWithContentsBase {
@@ -314,6 +318,7 @@ export interface BinaryOperator {
 
 export interface DirectiveElem extends AbstractElemBase {
   kind: "directive";
+  attributes: AttributeElem[];
   directive: DiagnosticDirective | EnableDirective | RequiresDirective;
 }
 
@@ -338,7 +343,7 @@ export interface FnElem extends ElemWithContentsBase {
   kind: "fn";
   name: DeclIdentElem;
   params: FnParamElem[];
-  fnAttributes?: AttributeElem[];
+  attributes: AttributeElem[];
   returnType?: TypeRefElem;
 }
 
@@ -356,6 +361,7 @@ export interface ModuleElem extends ElemWithContentsBase {
 /** an override declaration */
 export interface OverrideElem extends ElemWithContentsBase {
   kind: "override";
+  attributes: AttributeElem[];
   name: TypedDeclElem;
 }
 
@@ -399,7 +405,7 @@ export interface BindingStructElem extends StructElem {
 export interface StructMemberElem extends ElemWithContentsBase {
   kind: "member";
   name: NameElem;
-  attributes?: AttributeElem[];
+  attributes: AttributeElem[];
   typeRef: TypeRefElem;
   mangledVarName?: string; // root name if transformed to a var (for binding struct transformation)
 }
@@ -416,10 +422,22 @@ export interface TypeRefElem extends ElemWithContentsBase {
 /** a variable declaration */
 export interface VarElem extends ElemWithContentsBase {
   kind: "var";
+  attributes: AttributeElem[];
   name: TypedDeclElem;
 }
 
 export interface LetElem extends ElemWithContentsBase {
   kind: "let";
+  attributes: AttributeElem[];
   name: TypedDeclElem;
+}
+
+export interface AnyStatement extends ElemWithContentsBase {
+  kind: "statement";
+  attributes: AttributeElem[];
+}
+
+export interface SwitchClause extends ElemWithContentsBase {
+  kind: "switch-clause";
+  attributes: AttributeElem[];
 }

--- a/tools/packages/wesl/src/LowerAndEmit.ts
+++ b/tools/packages/wesl/src/LowerAndEmit.ts
@@ -75,6 +75,8 @@ export function lowerAndEmitElem(e: AbstractElem, ctx: EmitContext): void {
     case "expression":
     case "type":
     case "stuff":
+    case "statement":
+    case "switch-clause":
       return emitContents(e, ctx);
 
     // root level container elements get some extra newlines to make the output prettier

--- a/tools/packages/wesl/src/Reflection.ts
+++ b/tools/packages/wesl/src/Reflection.ts
@@ -119,23 +119,23 @@ function shaderVisiblity(struct: BindingStructElem): string {
   if (!entryFn) {
     identElemLog(struct.name, "missing entry function for binding struct");
   } else {
-    const { fnAttributes = [] } = entryFn;
+    const { attributes = [] } = entryFn;
     if (
-      fnAttributes.find(
+      attributes.find(
         ({ attribute: a }) => a.kind === "attribute" && a.name === "compute",
       )
     ) {
       return "GPUShaderStage.COMPUTE";
     }
     if (
-      fnAttributes.find(
+      attributes.find(
         ({ attribute: a }) => a.kind === "attribute" && a.name === "vertex",
       )
     ) {
       return "GPUShaderStage.VERTEX";
     }
     if (
-      fnAttributes.find(
+      attributes.find(
         ({ attribute: a }) => a.kind === "attribute" && a.name === "fragment",
       )
     ) {

--- a/tools/packages/wesl/src/WESLCollect.ts
+++ b/tools/packages/wesl/src/WESLCollect.ts
@@ -217,13 +217,12 @@ export const collectFn = collectElem(
     const name = cc.tags.fn_name?.[0] as DeclIdentElem;
     const body_scope = cc.tags.body_scope?.[0] as Scope;
     const params: FnParamElem[] = cc.tags.fnParam?.flat(3) ?? [];
-    const fnAttributes: AttributeElem[] | undefined =
-      cc.tags.fn_attributes?.flat();
+    const attributes: AttributeElem[] = cc.tags.fn_attributes?.flat() ?? [];
     const returnType: TypeRefElem | undefined = cc.tags.returnType?.flat(3)[0];
     const partElem: FnElem = {
       ...openElem,
       name,
-      fnAttributes,
+      attributes: attributes,
       params,
       returnType,
     };

--- a/tools/packages/wesl/src/debug/ASTtoString.ts
+++ b/tools/packages/wesl/src/debug/ASTtoString.ts
@@ -121,6 +121,10 @@ function addElemFields(elem: AbstractElem, str: LineWrapper): void {
     // Ignore
   } else if (kind === "directive") {
     addDirective(elem.directive, str);
+  } else if (kind === "statement") {
+    // Nothing to do for now
+  } else if (kind === "switch-clause") {
+    // Nothing to do for now
   } else {
     assertUnreachable(kind);
   }
@@ -170,7 +174,7 @@ function addTypedDeclIdent(elem: TypedDeclElem, str: LineWrapper) {
 }
 
 function addFnFields(elem: FnElem, str: LineWrapper) {
-  const { name, params, returnType, fnAttributes } = elem;
+  const { name, params, returnType, attributes } = elem;
 
   str.add(" " + name.ident.originalName);
 
@@ -190,7 +194,7 @@ function addFnFields(elem: FnElem, str: LineWrapper) {
   str.add(paramStrs);
   str.add(")");
 
-  fnAttributes?.forEach(a => addAttribute(a.attribute, str));
+  attributes?.forEach(a => addAttribute(a.attribute, str));
 
   if (returnType) {
     str.add(" -> " + typeRefElemToString(returnType));

--- a/tools/packages/wesl/src/parse/WeslGrammar.ts
+++ b/tools/packages/wesl/src/parse/WeslGrammar.ts
@@ -302,17 +302,22 @@ const compound_statement = tagScope(
   )
 );
 
-const for_init = or(
-  fn_call,
-  () => variable_or_value_statement,
-  () => variable_updating_statement,
+const for_init = seq(
+  opt_attributes, // TODO: Collect
+  or(
+    fn_call,
+    () => variable_or_value_statement,
+    () => variable_updating_statement,
+  ), // TODO: collect as AnyStatement and add the attributes
 );
 
-const for_update = or(fn_call, () => variable_updating_statement);
+const for_update = seq(
+  opt_attributes, // TODO: Collect and attach
+  or(fn_call, () => variable_updating_statement),
+);
 
 // prettier-ignore
 const for_statement = seq(
-  opt_attributes,
   "for",
   seq(
     req("("),
@@ -327,7 +332,6 @@ const for_statement = seq(
 );
 
 const if_statement = seq(
-  opt_attributes,
   "if",
   req(seq(expression, compound_statement)),
   repeat(seq("else", "if", req(seq(expression, compound_statement)))),
@@ -335,9 +339,8 @@ const if_statement = seq(
 );
 
 const loop_statement = seq(
-  opt_attributes,
   "loop",
-  opt_attributes,
+  opt_attributes, // TODO: collect and attach to scope 1
   req(
     seq(
       "{",
@@ -345,57 +348,59 @@ const loop_statement = seq(
       opt(
         seq(
           "continuing",
-          opt_attributes,
+          opt_attributes, // TODO: collect and attach to scope 2
           "{",
           repeat(() => statement),
           opt(seq("break", "if", expression, ";")),
-          "}",
+          "}", // TODO: Scope 2 collect
         ),
       ),
-      "}",
+      "}", // TODO: Scope 1 collect
     ),
   ),
 );
 
 const case_selector = or("default", expression);
-const switch_clause = or(
-  seq(
-    "case",
-    withSep(",", case_selector, { requireOne: true }),
-    opt(":"),
-    compound_statement,
-  ),
-  seq("default", opt(":"), compound_statement),
+const switch_clause = seq(
+  opt_attributes, // TODO: collect and then attach
+  or(
+    seq(
+      "case",
+      withSep(",", case_selector, { requireOne: true }),
+      opt(":"),
+      compound_statement,
+    ),
+    seq("default", opt(":"), compound_statement),
+  ), // TODO: collect as SwitchClause
 );
 
 const switch_body = seq(opt_attributes, "{", repeatPlus(switch_clause), "}");
-const switch_statement = seq(opt_attributes, "switch", expression, switch_body);
+const switch_statement = seq("switch", expression, switch_body);
 
-const while_statement = seq(
-  opt_attributes,
-  "while",
-  expression,
-  compound_statement,
-);
+const while_statement = seq("while", expression, compound_statement);
 
 const statement: Parser<Stream<WeslToken>, any> = or(
-  for_statement,
-  if_statement,
-  loop_statement,
-  switch_statement,
-  while_statement,
-  compound_statement,
-  seq("break", ";"),
-  seq("continue", ";"),
-  seq(";"),
-  () => const_assert,
-  seq("discard", ";"),
-  seq("return", opt(expression), ";"),
-  seq(fn_call, ";"),
-  seq(() => variable_or_value_statement, ";"),
-  seq(() => variable_updating_statement, ";"),
+  compound_statement, // This one is special and collects its own attributes
+  seq(
+    opt_attributes, // TODO: collect and then attach
+    or(
+      for_statement,
+      if_statement,
+      loop_statement,
+      switch_statement,
+      while_statement,
+      seq("break", ";"),
+      seq("continue", ";"),
+      seq(";"), // LATER this one cannot have attributes in front of it
+      () => const_assert,
+      seq("discard", ";"),
+      seq("return", opt(expression), ";"),
+      seq(fn_call, ";"),
+      seq(() => variable_or_value_statement, ";"),
+      seq(() => variable_updating_statement, ";"),
+    ), // TODO: Collect as AnyStatement
+  ),
 );
-
 // prettier-ignore
 const lhs_expression: Parser<Stream<WeslToken>,any> = or(
   simple_component_reference,
@@ -457,13 +462,14 @@ const fn_decl = seq(
 // prettier-ignore
 const global_value_decl = or(
   seq(
-    opt_attributes                    .collect((cc) => cc.tags.attribute, "attributes"),
+    opt_attributes                    .collect((cc) => cc.tags.attribute, "attributes"), // TODO: attach to override
     "override",
     optionally_typed_ident,
     seq(opt(seq("=", expression       .collect(scopeCollect(), "decl_scope")))),
     ";",
   )                                   .collect(collectVarLike("override")),
   seq(
+    opt_attributes                    .collect((cc) => cc.tags.attribute, "attributes"), // TODO: attach to const
     "const",
     optionally_typed_ident,
     "=",
@@ -485,6 +491,7 @@ const global_alias = seq(
 // prettier-ignore
 const const_assert = 
   seq(
+    opt_attributes, // TODO: collect and attach
     "const_assert", 
     req(expression), 
     ";"
@@ -492,18 +499,22 @@ const const_assert =
 );
 
 const global_directive = span(
-  terminated(
-    or(
-      preceded("diagnostic", diagnostic_control).map(makeDiagnosticDirective),
-      preceded("enable", name_list).map(makeEnableDirective),
-      preceded("requires", name_list).map(makeRequiresDirective),
+  seq(
+    opt_attributes,
+    terminated(
+      or(
+        preceded("diagnostic", diagnostic_control).map(makeDiagnosticDirective),
+        preceded("enable", name_list).map(makeEnableDirective),
+        preceded("requires", name_list).map(makeRequiresDirective),
+      ),
+      ";",
     ),
-    ";",
   ),
 ).map(
-  ({ value: directive, span: [start, end] }): DirectiveElem => ({
+  ({ value: [attributes, directive], span: [start, end] }): DirectiveElem => ({
     kind: "directive",
-    directive: directive,
+    directive,
+    attributes, // TODO: Convert this to a .collect
     start,
     end,
   }),
@@ -515,7 +526,7 @@ const global_decl = tagScope(
   or(
     fn_decl,
     seq(
-      opt_attributes, 
+      opt_attributes, // TODO: Attach attributes
       global_variable_decl, 
       ";")                          .collect(collectVarLike("gvar")),
     global_value_decl,


### PR DESCRIPTION
This adds some syntax tree nodes that we need to cover.
It also adds the attributes in the relevant places in the grammar. It doesn't hook them up though, since I struggle with that. My programming workflow is built around datatypes.

All the parts in the grammar where something needs to be done are marked with a TODO