### PR TITLE
fix: quiet noisy ErrorLogging.test.ts #102

### DIFF
--- a/tools/packages/wesl/src/BindIdents.ts
+++ b/tools/packages/wesl/src/BindIdents.ts
@@ -191,7 +191,7 @@ function bindIdentsRecursive(
         } else if (stdWgsl(ident.originalName)) {
           ident.std = true;
         } else {
-          warnMissingIdent(ident);
+          failMissingIdent(ident);
         }
       }
     }
@@ -253,13 +253,14 @@ function globalDeclToRootLiveDecls(decl: DeclIdent): LiveDecls | undefined {
 }
 
 /** warn the user about a missing identifer */
-function warnMissingIdent(ident: RefIdent): void {
+function failMissingIdent(ident: RefIdent): void {
   const { refIdentElem } = ident;
   if (refIdentElem) {
     const { srcModule, start, end } = refIdentElem;
     const { debugFilePath: filePath } = srcModule;
-    const msg = `unresolved identifier in file: ${filePath}`; // TODO make error message clickable
+    const msg = `unresolved identifier '${ident.originalName}' in file: ${filePath}`; // TODO make error message clickable
     srcLog(srcModule.src, [start, end], msg);
+    throw new Error(msg);
   }
 }
 

--- a/tools/packages/wesl/src/test/ErrorLogging.test.ts
+++ b/tools/packages/wesl/src/test/ErrorLogging.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from "vitest";
-import { linkWithLog } from "./TestUtil.ts";
+import { linkWithLogQuietly } from "./TestUtil.ts";
 
 test("unresolved identifier", async () => {
   const src = `
     fn main() { x = 7; }
     `;
-  const { log } = await linkWithLog(src);
+  const { log } = await linkWithLogQuietly(src);
   expect(log).toMatchInlineSnapshot(`
-    "unresolved identifier in file: ./test.wesl
+    "unresolved identifier 'x' in file: ./test.wesl
         fn main() { x = 7; }   Ln 2
                     ^^"
   `);

--- a/tools/packages/wesl/src/test/TestUtil.ts
+++ b/tools/packages/wesl/src/test/TestUtil.ts
@@ -46,8 +46,28 @@ export async function linkTestOpts(
   return srcMap.dest;
 }
 
-/** link wesl for tests, and return the console log as well */
+/** Link wesl for tests, and return the console log as well */
 export async function linkWithLog(...rawWgsl: string[]): Promise<{
+  log: string;
+  result: string;
+}> {
+  return linkWithLogInternal(rawWgsl);
+}
+
+/** Link wesl for tests, and return the console log as well. 
+ * Quietly swallow any exceptions thrown */
+export async function linkWithLogQuietly(...rawWgsl: string[]): Promise<{
+  log: string;
+  result: string;
+}> {
+  return linkWithLogInternal(rawWgsl, true);
+}
+
+/** link wesl for tests */
+async function linkWithLogInternal(
+  rawWgsl: string[],
+  quiet = false,
+): Promise<{
   log: string;
   result: string;
 }> {
@@ -56,7 +76,7 @@ export async function linkWithLog(...rawWgsl: string[]): Promise<{
   try {
     result = await withLoggerAsync(log, async () => linkTest(...rawWgsl));
   } catch (e) {
-    console.error(e);
+    if (!quiet) console.error(e);
   }
   return { result, log: logged() };
 }


### PR DESCRIPTION
Fix noise by throwing on binding failure and logging appropriately. 

There are other ways to quiet the test, but I think it's probably wise to not proceed to emit if binding fails. This does the simple thing and throws at the first error. 

But perhaps we should collect more errors first, or return errors without throwing.