### PR TITLE
Add main field for bundlephobia

### DIFF
--- a/tools/packages/wesl/package.json
+++ b/tools/packages/wesl/package.json
@@ -23,6 +23,7 @@
   },
   "type": "module",
   "repository": "github:wgsl-tooling-wg/wesl-js",
+  "main": "dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/tools/packages/wesl/src/index.d.ts",


### PR DESCRIPTION
Currently going to https://bundlephobia.com/package/wesl just throws an error. This hopefully fixes that?

Error seems to be https://github.com/pastelsky/bundlephobia/issues/379