### PR TITLE
Export mangler types/functions to npm package

### DIFF
--- a/tools/packages/wesl/src/index.ts
+++ b/tools/packages/wesl/src/index.ts
@@ -3,6 +3,7 @@ export * from "./debug/ASTtoString.js";
 export * from "./debug/ScopeToString.js";
 export * from "./LinkedWesl.js";
 export * from "./Linker.js";
+export * from "./Mangler.js";
 export { WeslStream } from "./parse/WeslStream.js";
 export * from "./ParsedRegistry.js";
 export * from "./ParseWESL.js";


### PR DESCRIPTION
The npm package does not give access to predefined mangler functions, `underscoreMangle` and  `lengthPrefixMangle` which I copy-pasted in `wesl-playground`.

I believe this is the way to fix it, but please double check :)