### PR TITLE
(vitest-image-snapshot) Handle invalid filename characters in snapshot names

### DIFF
--- a/packages/vitest-image-snapshot/src/SnapshotManager.ts
+++ b/packages/vitest-image-snapshot/src/SnapshotManager.ts
@@ -1,6 +1,20 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+const REPLACEABLE_INVALID_CHARS = /[<>:"\/\\|?*]/g;
+
+// since we always add '.png' to the end, there's no need to handle trailing
+// dots, which are only invalid at the end of the whole name.  spaces around
+// the outside of the snapshot name are handled with trim()
+const UNREPLACEABLE_INVALID_CHARS = /\p{Control}+/gu;
+
+function sanitizeName(input: string): string {
+  return input
+    .replace(REPLACEABLE_INVALID_CHARS, "_")
+    .replace(UNREPLACEABLE_INVALID_CHARS, "")
+    .trim();
+}
+
 export interface SnapshotConfig {
   snapshotDir?: string;
   diffDir?: string;
@@ -29,7 +43,7 @@ export class ImageSnapshotManager {
     return path.join(
       this.testDir,
       this.config.snapshotDir,
-      `${snapshotName}.png`,
+      `${sanitizeName(snapshotName)}.png`,
     );
   }
 
@@ -37,12 +51,16 @@ export class ImageSnapshotManager {
     return path.join(
       this.testDir,
       this.config.actualDir,
-      `${snapshotName}.png`,
+      `${sanitizeName(snapshotName)}.png`,
     );
   }
 
   diffPath(snapshotName: string): string {
-    return path.join(this.testDir, this.config.diffDir, `${snapshotName}.png`);
+    return path.join(
+      this.testDir,
+      this.config.diffDir,
+      `${sanitizeName(snapshotName)}.png`,
+    );
   }
 
   /** Update failing snapshots (only in "all" mode with vitest -u) */

--- a/packages/vitest-image-snapshot/src/test/SnapshotManager.test.ts
+++ b/packages/vitest-image-snapshot/src/test/SnapshotManager.test.ts
@@ -17,6 +17,91 @@ test("generates correct file paths", () => {
   );
 });
 
+test("handles invalid chars in snapshot name for all path types", () => {
+  const testPath = path.join("/path/to/test.ts");
+  const manager = new ImageSnapshotManager(testPath);
+
+  expect(manager.referencePath("Category > test name")).toBe(
+    path.join("/path/to", "__image_snapshots__", "Category _ test name.png"),
+  );
+  expect(manager.actualPath("Category > test name")).toBe(
+    path.join("/path/to", "__image_actual__", "Category _ test name.png"),
+  );
+  expect(manager.diffPath("Category > test name")).toBe(
+    path.join("/path/to", "__image_diffs__", "Category _ test name.png"),
+  );
+});
+
+test("handles replaceable invalid chars in snapshot name", () => {
+  const testPath = path.join("/path/to/test.ts");
+  const manager = new ImageSnapshotManager(testPath);
+
+  // since we've shown that all path types are passed through sanitizeName, it's
+  // enough to stick to one type for these.
+
+  // handles multiple replaceable chars
+  expect(manager.referencePath("Category > test name > subtitle")).toBe(
+    path.join(
+      "/path/to",
+      "__image_snapshots__",
+      "Category _ test name _ subtitle.png",
+    ),
+  );
+
+  // handles all known replaceable chars
+  expect(manager.referencePath('Category <>:"/\\|?* test')).toBe(
+    path.join("/path/to", "__image_snapshots__", "Category _________ test.png"),
+  );
+
+  // handles invalid chars at start
+  expect(manager.referencePath("> test")).toBe(
+    path.join("/path/to", "__image_snapshots__", "_ test.png"),
+  );
+
+  // handles invalid chars at end
+  expect(manager.referencePath("test >")).toBe(
+    path.join("/path/to", "__image_snapshots__", "test _.png"),
+  );
+});
+
+test("handles unreplaceable invalid chars in snapshot name", () => {
+  const testPath = path.join("/path/to/test.ts");
+  const manager = new ImageSnapshotManager(testPath);
+
+  // since we've shown that all path types are passed through sanitizeName, it's
+  // enough to stick to one type for these.
+
+  // handles unreplaceable chars
+  expect(manager.referencePath("Category \x02 test name")).toBe(
+    path.join("/path/to", "__image_snapshots__", "Category  test name.png"),
+  );
+
+  // handles multiple unreplaceable chars
+  expect(manager.referencePath("Category \x02\x03 test name")).toBe(
+    path.join("/path/to", "__image_snapshots__", "Category  test name.png"),
+  );
+
+  // handles unreplaceables at the beginning
+  expect(manager.referencePath("\x02\x03word1 word2")).toBe(
+    path.join("/path/to", "__image_snapshots__", "word1 word2.png"),
+  );
+
+  // handles unreplaceables at the end
+  expect(manager.referencePath("word1 word2\x02\x03")).toBe(
+    path.join("/path/to", "__image_snapshots__", "word1 word2.png"),
+  );
+
+  // handles extra space on the outside
+  expect(manager.referencePath(" word1 word2 \x02 \x03 ")).toBe(
+    path.join("/path/to", "__image_snapshots__", "word1 word2.png"),
+  );
+
+  // handles mixed invalid chars
+  expect(manager.referencePath(" word1 >\x02<\x03 word2 \x02 \x03 ")).toBe(
+    path.join("/path/to", "__image_snapshots__", "word1 __ word2.png"),
+  );
+});
+
 test("supports custom directory names", () => {
   const testPath = path.join("/path/to/test.ts");
   const manager = new ImageSnapshotManager(testPath, {


### PR DESCRIPTION
snapshotName may sometimes include characters that are not valid on some filesystems (for example, when using describe() on Windows a ">" will cause writing snapshots to fail).

This handles two classes of invalid character: replaceable and unreplaceable. Replaceable characters are replaced with _ when sanitizing, and unreplaceable are simply removed.

Fixes #192.